### PR TITLE
Fixed broken URL

### DIFF
--- a/doc_source/view-cloudtrail-events-supported-services.md
+++ b/doc_source/view-cloudtrail-events-supported-services.md
@@ -1540,7 +1540,7 @@ For more information, see [Logging Amazon Kinesis Data Streams API Calls Using A
 | UpdateFunctionConfiguration20150331 | 
 | UpdateFunctionConfiguration20150331v2 | 
 
-For more information, see [Logging AWS Lambda API Calls Using AWS CloudTrail](http://docs.aws.amazon.com/lambda/latest/dg/logging_using_cloudtrail.html) in the *AWS Lambda Developer Guide*\.
+For more information, see [Logging AWS Lambda API Calls Using AWS CloudTrail](https://docs.aws.amazon.com/lambda/latest/dg/logging-using-cloudtrail.html) in the *AWS Lambda Developer Guide*\.
 
 ## Amazon Lex APIs<a name="view-cloudtrail-events-supported-apis-lex"></a>
 


### PR DESCRIPTION

*Description of changes:* URL was broken and redirects to the Lambda docs welcome page. Replaced with correct URL

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._
