### PR TITLE
some fixes for clarity

### DIFF
--- a/doc_source/shared-event-ID.md
+++ b/doc_source/shared-event-ID.md
@@ -4,11 +4,11 @@ The following is an example that describes how CloudTrail delivers two events fo
 
 1.  Alice has AWS account \(111111111111\) and creates a customer master key \(CMK\)\. She is the owner of this CMK\. 
 
-1.  Bob has AWS account \(222222222222\)\. Alice gives Bob permission to use the CMK\. 
+1.  Bob has AWS account \(222222222222\)\. Alice gives AWS account \(222222222222\)\ permission to use the CMK\. 
 
 1.  Each account has a trail and a separate bucket\.
 
-1.  Bob uses the CMK to call the `Encrypt` API\. 
+1.  Bob calls the `Encrypt` API specifying Alice's CMK\. 
 
 1.  CloudTrail sends two separate events\. 
    + One event is sent to Bob\. The event shows that he used the CMK\.


### PR DESCRIPTION
*Description of changes:*

> "Bob uses the CMK to call the Encrypt API."

This is confusing (at best.)

> "Alice gives Bob permission to use the CMK."

Account 1 can't limit access to one of its resources to a particular principal (Bob) in account 2.  Account 2 can enforce these kinds of limits.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
