### PR TITLE
Removing non-working conditions

### DIFF
--- a/doc_source/cloudtrail-set-bucket-policy-for-multiple-accounts.md
+++ b/doc_source/cloudtrail-set-bucket-policy-for-multiple-accounts.md
@@ -49,5 +49,3 @@ An AWS account ID is a twelve\-digit number, and leading zeros must not be omitt
      ]
    }
    ```
-
-1. \(Optional\) Restrict access to the S3 bucket to either a specific AWS Organization or account by using the global condition keys [https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#principal-org-id](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#principal-org-id) or [https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-sourceaccount](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_condition-keys.html#condition-keys-sourceaccount)\. For more information about how to restrict access to S3 buckets by using global condition keys, see [Specifying Conditions in a Policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/amazon-s3-policy-keys.html) in the *Amazon Simple Storage Service Developer Guide*\.


### PR DESCRIPTION
According to AWS support, it is not possible to use condition keys like aws:PrincipalOrgId or aws:SourceAccount as the CloudTrail service does not operate within ones AWS account. Because of this, these keys are not available which causes CloudTrail to lose access to the bucket.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
