### PR TITLE
Update cloudtrail-log-file-validation-enabling.md

### DIFF
--- a/doc_source/cloudtrail-log-file-validation-enabling.md
+++ b/doc_source/cloudtrail-log-file-validation-enabling.md
@@ -22,4 +22,4 @@ aws cloudtrail update-trail --name your-trail-name --enable-log-file-validation
 
  To enable log file integrity validation with the CloudTrail API, set the `EnableLogFileValidation` request parameter to `true` when calling `CreateTrail` or `UpdateTrail`\. 
 
- For more information, see [CreateTrail](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/api_CreateTrail.html) and [UpdateTrail](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_UpdateTrail.html) in the [AWS CloudTrail API Reference](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/)\.
+ For more information, see [CreateTrail](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_CreateTrail.html) and [UpdateTrail](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_UpdateTrail.html) in the [AWS CloudTrail API Reference](https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/)\.


### PR DESCRIPTION
Typo in CreateTrail link

*Issue #, if available:*

*Description of changes:*
The CreateTrail link to the API documentation had the following typo:
`https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/api_CreateTrail.html` - wrong
`https://docs.aws.amazon.com/awscloudtrail/latest/APIReference/API_CreateTrail.html` - correct


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
