### PR TITLE
Fixed access permissions issue

### DIFF
--- a/doc_source/cloudtrail-set-bucket-policy-for-multiple-accounts.md
+++ b/doc_source/cloudtrail-set-bucket-policy-for-multiple-accounts.md
@@ -44,7 +44,11 @@ An AWS account ID is a twelve\-digit number, and leading zeros must not be omitt
            "arn:aws:s3:::myBucketName/[optional] myLogFilePrefix/AWSLogs/222222222222/*"
          ],
          "Condition": { 
-           "StringEquals": { 
+           "StringEquals": {
+             "AWS:SourceArn": [
+                  "arn:aws:cloudtrail:region:111111111111:trail/trailName",
+                  "arn:aws:cloudtrail:region:222222222222:trail/trailName"
+              ],
              "s3:x-amz-acl": "bucket-owner-full-control" 
            }
          }


### PR DESCRIPTION
Fixed "The S3 bucket policy might not have adequate permissions for CloudTrail to access it" error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
