### PR TITLE
Clarify the communication path between VPC resources and CloudTrail

### DIFF
--- a/doc_source/cloudtrail-and-interface-VPC.md
+++ b/doc_source/cloudtrail-and-interface-VPC.md
@@ -1,6 +1,6 @@
 # Using AWS CloudTrail with interface VPC endpoints<a name="cloudtrail-and-interface-VPC"></a>
 
-If you use Amazon Virtual Private Cloud \(Amazon VPC\) to host your AWS resources, you can establish a private connection between your VPC and AWS CloudTrail\. You can use this connection to enable CloudTrail to communicate with your resources on your VPC without going through the public internet\.
+If you use Amazon Virtual Private Cloud \(Amazon VPC\) to host your AWS resources, you can establish a private connection between your VPC and AWS CloudTrail\. You can use this connection to enable your resources on your VPC to communicate with CloudTrail without going through the public internet\.
 
 Amazon VPC is an AWS service that you can use to launch AWS resources in a virtual network that you define\. With a VPC, you have control over your network settings, such the IP address range, subnets, route tables, and network gateways\. With VPC endpoints, the routing between the VPC and AWS services is handled by the AWS network, and you can use IAM policies to control access to service resources\.
 


### PR DESCRIPTION
It is VPC resources that can communicated directly with VPC endpoint for CloudTrail instead of CloudTrail communicating with VPC resources.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
